### PR TITLE
fix(broker): include actual error details in PTY spawn failures

### DIFF
--- a/packages/opencode-broker/src/ipc/handler.rs
+++ b/packages/opencode-broker/src/ipc/handler.rs
@@ -534,7 +534,7 @@ async fn handle_spawn_pty(
         Ok(p) => p,
         Err(e) => {
             error!(error = %e, "failed to allocate PTY");
-            return Response::failure(&request.id, "failed to allocate PTY");
+            return Response::failure(&request.id, format!("failed to allocate PTY: {}", e));
         }
     };
 
@@ -559,7 +559,7 @@ async fn handle_spawn_pty(
         Ok(c) => c,
         Err(e) => {
             error!(error = %e, "failed to spawn process");
-            return Response::failure(&request.id, "failed to spawn process");
+            return Response::failure(&request.id, format!("failed to spawn process: {}", e));
         }
     };
 
@@ -716,7 +716,7 @@ async fn handle_resize_pty(request: Request, pty_sessions: &SessionManager) -> R
     if result < 0 {
         let err = std::io::Error::last_os_error();
         error!(error = %err, "failed to resize PTY");
-        return Response::failure(&request.id, "failed to resize PTY");
+        return Response::failure(&request.id, format!("failed to resize PTY: {}", err));
     }
 
     // Update stored dimensions


### PR DESCRIPTION
Previously, when PTY allocation, process spawn, or resize operations failed, the broker returned generic error messages like "failed to spawn process" without including the underlying cause. This made debugging terminal issues difficult as users couldn't see what actually failed (e.g., "No such file or directory" for missing shells).

Now the broker includes the actual error in the response message, enabling better error reporting to the client and easier debugging.

https://claude.ai/code/session_016zXuT1Z8kJr5gAjacA7cSk

### What does this PR do?

### How did you verify your code works?
