### PR TITLE
chore: harden post-catch-up upstream sync operations

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -9,6 +9,11 @@ concurrency:
   group: sync-upstream
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   sync:
     runs-on: ubuntu-24.04
@@ -17,7 +22,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.UPSTREAM_SYNC_TOKEN }}
+          token: ${{ secrets.UPSTREAM_SYNC_TOKEN || github.token }}
+
+      - name: Verify parent-dev mirror
+        run: ./script/verify-upstream-mirror.sh
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
@@ -25,5 +33,5 @@ jobs:
       - name: Sync upstream
         run: ./script/sync-upstream.ts
         env:
-          GH_TOKEN: ${{ secrets.UPSTREAM_SYNC_TOKEN }}
-          UPSTREAM_SYNC_TOKEN: ${{ secrets.UPSTREAM_SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.UPSTREAM_SYNC_TOKEN || github.token }}
+          UPSTREAM_SYNC_TOKEN: ${{ secrets.UPSTREAM_SYNC_TOKEN || github.token }}

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -4,9 +4,10 @@
 - Upstream repo/branch: `anomalyco/opencode` `dev`
 - Fork repo/branch: `pRizz/opencode` `dev`
 - Merge base: see `docs/upstream-sync/merge-base.txt`
-- Current divergence: `0` behind / `418` ahead (`git rev-list --left-right --count upstream/dev...origin/dev`)
+- Current divergence: `0` behind / `423` ahead (`git rev-list --left-right --count upstream/dev...origin/dev`)
 - `parent-dev` mirror status: `0 0` (`git rev-list --left-right --count upstream/dev...origin/parent-dev`)
 - Catch-up status: upstream catch-up complete; fork decoupling restored post-catch-up.
+- Post-catch-up snapshot artifact: `docs/upstream-sync/post-catchup-state.txt`
 
 ## Patchset Report
 - Restore manifest: `docs/upstream-sync/restore-missing-commits.txt`
@@ -47,15 +48,36 @@ wc -l docs/upstream-sync/upstream-first-parent.txt > docs/upstream-sync/upstream
 ## Ongoing Sync Automation
 - Script: `script/sync-upstream.ts`
 - Workflow: `.github/workflows/sync-upstream.yml` (runs every 3 hours)
-- Secrets required: `UPSTREAM_SYNC_TOKEN` (fine-grained PAT or GitHub App token)
+- Mirror verification script: `script/verify-upstream-mirror.sh`
+- Token behavior: uses `UPSTREAM_SYNC_TOKEN` when configured, otherwise falls back to `${{ github.token }}`.
 - Workflow behavior:
+  - Verifies `upstream/dev...origin/parent-dev` is `0 0` before running sync.
   - Updates `parent-dev` to match `upstream/dev` (force push).
   - Opens a sync PR when upstream is ahead.
   - Enables auto-merge once checks pass.
   - On conflict, opens an issue labeled `sync-conflict` with merge details.
 
+Manual dispatch and monitoring:
+```bash
+gh workflow run sync-upstream.yml --ref dev --repo pRizz/opencode
+gh run list --workflow sync-upstream.yml --repo pRizz/opencode --limit 1
+gh run view <run-id> --repo pRizz/opencode --log
+```
+
+Conflict handling:
+1. Check the `sync-conflict` issue for merge-base and conflict context.
+2. Create `sync/catchup-hotfix-<date>` from `dev`.
+3. Resolve conflicts with `docs/upstream-sync/fork-feature-audit.md` as ownership source of truth.
+4. Regenerate SDK, run typecheck/smoke, and merge immediately.
+
+Post-merge validation order:
+1. `./packages/sdk/js/script/build.ts`
+2. `bun turbo typecheck`
+3. Smoke in `packages/opencode`: `bun run dev:web` then `bun dev`
+
 ## Repo Settings Checklist
 - Enable auto-merge on the repository.
-- Require `test` and `typecheck` checks on `dev`.
+- Require `check-standards`, `typecheck`, and `test` checks on `dev`.
 - Allow merge commits.
-- Ensure the PAT/App used by `UPSTREAM_SYNC_TOKEN` can create PRs, labels, and enable auto-merge.
+- Disable force pushes to `dev`.
+- Require pull requests and up-to-date branches before merge.

--- a/docs/upstream-sync/fork-feature-audit.md
+++ b/docs/upstream-sync/fork-feature-audit.md
@@ -5,10 +5,11 @@ Purpose: track **all** fork deltas and keep them preserved during upstream merge
 ## Status
 - Snapshot date: 2026-02-06
 - Base comparison: `upstream/dev...dev`
-- Current divergence: `0` behind / `418` ahead (`git rev-list --left-right --count upstream/dev...dev`)
+- Current divergence: `0` behind / `423` ahead (`git rev-list --left-right --count upstream/dev...dev`)
 - `parent-dev` mirror: `0 0` (`git rev-list --left-right --count upstream/dev...parent-dev`)
 - Source artifacts: `docs/upstream-sync/restore-missing-commits.txt`, `docs/upstream-sync/restore-file-map.txt`
 - Catch-up status: upstream catch-up is complete; this file reflects post-catch-up decoupling restoration from `sync/decouple-fork-layer`.
+- Continuous sync status: `.github/workflows/sync-upstream.yml` active; `parent-dev` stays mirrored to `upstream/dev`.
 
 ## A. System Authentication & Security (Core Runtime)
 
@@ -223,8 +224,9 @@ Purpose: track **all** fork deltas and keep them preserved during upstream merge
 ## I. Infra / CI / Workflows
 
 - Workflows under `.github/workflows/**`
-- Fork upstream sync automation: `.github/workflows/fork-sync-upstream.yml`
+- Fork upstream sync automation: `.github/workflows/sync-upstream.yml`
 - Fork sync orchestrator script: `script/sync-upstream.ts`
+- Upstream mirror verification script: `script/verify-upstream-mirror.sh`
 - Nix/flake updates: `flake.nix`, `flake.lock`, `nix/**`
 - Containers: `packages/containers/**`
 
@@ -263,6 +265,3 @@ Purpose: track **all** fork deltas and keep them preserved during upstream merge
 ## Notes
 - This is the restored post-catch-up inventory. Update this checklist whenever fork behavior ownership changes.
 - Fork hook packages: `packages/fork-auth`, `packages/fork-ui`, `packages/fork-terminal`, `packages/fork-cli`, `packages/fork-security`, `packages/fork-provider`, `packages/fork-config`.
-
-## Remaining Areas
-- None (current decoupling checklist complete)

--- a/docs/upstream-sync/post-catchup-state.txt
+++ b/docs/upstream-sync/post-catchup-state.txt
@@ -1,0 +1,6 @@
+# Post-catchup baseline snapshot
+captured_at_utc: 2026-02-06T03:59:56Z
+upstream_dev_vs_origin_dev_left_right_count: 0	423
+upstream_dev_vs_origin_parent_dev_left_right_count: 0	0
+origin_dev_sha: 7f2140803b00f8aee6f9179e14ffeabe5784a763
+upstream_dev_sha: 8bf97ef9e5a4039e80bfb3d565d4718da6114afd

--- a/script/sync-upstream.ts
+++ b/script/sync-upstream.ts
@@ -102,8 +102,8 @@ async function main() {
   await $`git fetch ${REMOTE_UPSTREAM} --tags`
   await $`git fetch ${REMOTE_ORIGIN} ${DEV_BRANCH}`
 
-  await $`git checkout ${DEV_BRANCH}`
-  await $`git reset --hard ${REMOTE_ORIGIN}/${DEV_BRANCH}`
+  // Avoid ambiguous branch resolution once both origin/dev and upstream/dev exist.
+  await $`git checkout -B ${DEV_BRANCH} ${REMOTE_ORIGIN}/${DEV_BRANCH}`
 
   await $`git branch -f ${PARENT_BRANCH} ${REMOTE_UPSTREAM}/${UPSTREAM_BRANCH}`
   await $`git push ${REMOTE_ORIGIN} ${PARENT_BRANCH} --force`

--- a/script/verify-upstream-mirror.sh
+++ b/script/verify-upstream-mirror.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE_UPSTREAM="upstream"
+REMOTE_ORIGIN="origin"
+UPSTREAM_REPO_URL="https://github.com/anomalyco/opencode.git"
+UPSTREAM_BRANCH="dev"
+PARENT_BRANCH="parent-dev"
+
+if ! git remote get-url "${REMOTE_UPSTREAM}" >/dev/null 2>&1; then
+  git remote add "${REMOTE_UPSTREAM}" "${UPSTREAM_REPO_URL}"
+fi
+
+git fetch "${REMOTE_UPSTREAM}" "${UPSTREAM_BRANCH}"
+git fetch "${REMOTE_ORIGIN}" "${PARENT_BRANCH}"
+
+counts="$(git rev-list --left-right --count ${REMOTE_UPSTREAM}/${UPSTREAM_BRANCH}...${REMOTE_ORIGIN}/${PARENT_BRANCH})"
+left="${counts%%[[:space:]]*}"
+right="${counts##*[[:space:]]}"
+
+if [[ "${left}" != "0" || "${right}" != "0" ]]; then
+  echo "parent-dev mirror drift detected: upstream/dev...origin/parent-dev = ${counts}" >&2
+  exit 1
+fi
+
+echo "parent-dev mirror verified: upstream/dev...origin/parent-dev = ${counts}"


### PR DESCRIPTION
## Summary\n- add post-catchup baseline snapshot artifact under docs/upstream-sync\n- harden sync workflow token handling with github.token fallback\n- add parent-dev mirror verification script and workflow gate\n- fix sync script checkout to avoid ambiguous dev tracking branch in Actions\n- update sync runbook and fork audit with current canonical workflow + completion notes\n\n## Validation\n- ./script/verify-upstream-mirror.sh\n- manual workflow_dispatch run on branch: sync-upstream (run 21738297332) succeeded as no-op\n- branch protection configured on dev with required checks: check-standards, typecheck, test (linux)\n