### PR TITLE
sync: post-catchup stabilization follow-up v2

### DIFF
--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -4,7 +4,7 @@
 - Upstream repo/branch: `anomalyco/opencode` `dev`
 - Fork repo/branch: `pRizz/opencode` `dev`
 - Merge base: see `docs/upstream-sync/merge-base.txt`
-- Current divergence: `0` behind / `423` ahead (`git rev-list --left-right --count upstream/dev...origin/dev`)
+- Current divergence: `0` behind / `429` ahead (`git rev-list --left-right --count upstream/dev...origin/dev`)
 - `parent-dev` mirror status: `0 0` (`git rev-list --left-right --count upstream/dev...origin/parent-dev`)
 - Catch-up status: upstream catch-up complete; fork decoupling restored post-catch-up.
 - Post-catch-up snapshot artifact: `docs/upstream-sync/post-catchup-state.txt`
@@ -77,7 +77,7 @@ Post-merge validation order:
 
 ## Repo Settings Checklist
 - Enable auto-merge on the repository.
-- Require `check-standards`, `typecheck`, and `test` checks on `dev`.
+- Require `typecheck` and `test (linux)` checks on `dev`.
 - Allow merge commits.
 - Disable force pushes to `dev`.
 - Require pull requests and up-to-date branches before merge.

--- a/docs/upstream-sync/fork-feature-audit.md
+++ b/docs/upstream-sync/fork-feature-audit.md
@@ -5,7 +5,7 @@ Purpose: track **all** fork deltas and keep them preserved during upstream merge
 ## Status
 - Snapshot date: 2026-02-06
 - Base comparison: `upstream/dev...dev`
-- Current divergence: `0` behind / `423` ahead (`git rev-list --left-right --count upstream/dev...dev`)
+- Current divergence: `0` behind / `429` ahead (`git rev-list --left-right --count upstream/dev...dev`)
 - `parent-dev` mirror: `0 0` (`git rev-list --left-right --count upstream/dev...parent-dev`)
 - Source artifacts: `docs/upstream-sync/restore-missing-commits.txt`, `docs/upstream-sync/restore-file-map.txt`
 - Catch-up status: upstream catch-up is complete; this file reflects post-catch-up decoupling restoration from `sync/decouple-fork-layer`.

--- a/docs/upstream-sync/post-catchup-state.txt
+++ b/docs/upstream-sync/post-catchup-state.txt
@@ -1,6 +1,6 @@
 # Post-catchup baseline snapshot
-captured_at_utc: 2026-02-06T03:59:56Z
-upstream_dev_vs_origin_dev_left_right_count: 0	423
+captured_at_utc: 2026-02-06T04:38:47Z
+upstream_dev_vs_origin_dev_left_right_count: 0	429
 upstream_dev_vs_origin_parent_dev_left_right_count: 0	0
-origin_dev_sha: 7f2140803b00f8aee6f9179e14ffeabe5784a763
+origin_dev_sha: 71cd1ce0ebb1dbcc8cb9a9273bbe46fbd1bfd91d
 upstream_dev_sha: 8bf97ef9e5a4039e80bfb3d565d4718da6114afd


### PR DESCRIPTION
## Summary
- refresh post-catchup baseline snapshot against latest dev
- align upstream sync runbook and fork audit divergence/check-policy text
- validate manual `sync-upstream` no-op path on latest dev

## Validation
- manual run `21738936402` succeeded
- log contains mirror check: `parent-dev mirror verified: upstream/dev...origin/parent-dev = 0 0`
- log contains no-op: `Upstream is already merged. Nothing to sync.`
- repo settings confirmed: auto-merge enabled, issues enabled
- branch protection confirmed required checks: `typecheck`, `test (linux)`
