### PR TITLE
sync: steady-state upstream sync hardening refresh

### DIFF
--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -4,7 +4,7 @@
 - Upstream repo/branch: `anomalyco/opencode` `dev`
 - Fork repo/branch: `pRizz/opencode` `dev`
 - Merge base: see `docs/upstream-sync/merge-base.txt`
-- Current divergence: `0` behind / `429` ahead (`git rev-list --left-right --count upstream/dev...origin/dev`)
+- Current divergence: `0` behind / `431` ahead (`git rev-list --left-right --count upstream/dev...origin/dev`)
 - `parent-dev` mirror status: `0 0` (`git rev-list --left-right --count upstream/dev...origin/parent-dev`)
 - Catch-up status: upstream catch-up complete; fork decoupling restored post-catch-up.
 - Post-catch-up snapshot artifact: `docs/upstream-sync/post-catchup-state.txt`
@@ -74,6 +74,20 @@ Post-merge validation order:
 1. `./packages/sdk/js/script/build.ts`
 2. `bun turbo typecheck`
 3. Smoke in `packages/opencode`: `bun run dev:web` then `bun dev`
+
+## Steady-State Verification Cadence
+- Daily quick check:
+  - `gh run list --workflow sync-upstream.yml --repo pRizz/opencode --limit 5`
+  - confirm recent `sync-upstream` runs are green.
+- Daily divergence check:
+  - `git fetch origin dev && git fetch upstream dev`
+  - `git rev-list --left-right --count upstream/dev...origin/dev`
+  - `git rev-list --left-right --count upstream/dev...origin/parent-dev`
+- Weekly manual drill:
+  - `gh workflow run sync-upstream.yml --ref dev --repo pRizz/opencode`
+  - confirm logs include:
+    - `parent-dev mirror verified: upstream/dev...origin/parent-dev = 0 0`
+    - `Upstream is already merged. Nothing to sync.` (when no-op)
 
 ## Repo Settings Checklist
 - Enable auto-merge on the repository.

--- a/docs/upstream-sync/fork-feature-audit.md
+++ b/docs/upstream-sync/fork-feature-audit.md
@@ -5,7 +5,7 @@ Purpose: track **all** fork deltas and keep them preserved during upstream merge
 ## Status
 - Snapshot date: 2026-02-06
 - Base comparison: `upstream/dev...dev`
-- Current divergence: `0` behind / `429` ahead (`git rev-list --left-right --count upstream/dev...dev`)
+- Current divergence: `0` behind / `431` ahead (`git rev-list --left-right --count upstream/dev...dev`)
 - `parent-dev` mirror: `0 0` (`git rev-list --left-right --count upstream/dev...parent-dev`)
 - Source artifacts: `docs/upstream-sync/restore-missing-commits.txt`, `docs/upstream-sync/restore-file-map.txt`
 - Catch-up status: upstream catch-up is complete; this file reflects post-catch-up decoupling restoration from `sync/decouple-fork-layer`.

--- a/docs/upstream-sync/post-catchup-state.txt
+++ b/docs/upstream-sync/post-catchup-state.txt
@@ -1,6 +1,6 @@
 # Post-catchup baseline snapshot
-captured_at_utc: 2026-02-06T04:38:47Z
-upstream_dev_vs_origin_dev_left_right_count: 0	429
+captured_at_utc: 2026-02-06T04:54:14Z
+upstream_dev_vs_origin_dev_left_right_count: 0	431
 upstream_dev_vs_origin_parent_dev_left_right_count: 0	0
-origin_dev_sha: 71cd1ce0ebb1dbcc8cb9a9273bbe46fbd1bfd91d
+origin_dev_sha: fe6375d2ec61d8c266c1c7986fb5151810396253
 upstream_dev_sha: 8bf97ef9e5a4039e80bfb3d565d4718da6114afd


### PR DESCRIPTION
## Summary
- refresh post-catchup baseline snapshot to current dev head and divergence
- update upstream sync playbook divergence and add explicit steady-state verification cadence
- refresh fork audit divergence count

## Operational verification performed
- `upstream/dev...origin/dev = 0 431`
- `upstream/dev...origin/parent-dev = 0 0`
- manual `sync-upstream` drill succeeded: run `21739214550`
- log proof lines:
  - `parent-dev mirror verified: upstream/dev...origin/parent-dev = 0 0`
  - `Upstream is already merged. Nothing to sync.`
- repo controls verified:
  - auto-merge enabled
  - issues enabled
  - branch protection required checks: `typecheck`, `test (linux)`

## Notes
- local merged catch-up branches were cleaned up; active local sync branches now: `sync/catchup-001`, `sync/decouple-fork-layer`
