### PR TITLE
fix(sync): allow stale parent-dev mirror precheck

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.UPSTREAM_SYNC_TOKEN || github.token }}
 
-      - name: Verify parent-dev mirror
+      - name: Verify parent-dev mirror health
         run: ./script/verify-upstream-mirror.sh
 
       - name: Setup Bun

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -51,7 +51,9 @@ wc -l docs/upstream-sync/upstream-first-parent.txt > docs/upstream-sync/upstream
 - Mirror verification script: `script/verify-upstream-mirror.sh`
 - Token behavior: uses `UPSTREAM_SYNC_TOKEN` when configured, otherwise falls back to `${{ github.token }}`.
 - Workflow behavior:
-  - Verifies `upstream/dev...origin/parent-dev` is `0 0` before running sync.
+  - Verifies mirror health before running sync:
+    - fails only if `origin/parent-dev` has commits not in `upstream/dev` (unsafe drift)
+    - allows upstream-ahead stale state and lets sync refresh `parent-dev` via force update
   - Updates `parent-dev` to match `upstream/dev` (force push).
   - Opens a sync PR when upstream is ahead.
   - Enables auto-merge once checks pass.

--- a/script/verify-upstream-mirror.sh
+++ b/script/verify-upstream-mirror.sh
@@ -18,9 +18,16 @@ counts="$(git rev-list --left-right --count ${REMOTE_UPSTREAM}/${UPSTREAM_BRANCH
 left="${counts%%[[:space:]]*}"
 right="${counts##*[[:space:]]}"
 
-if [[ "${left}" != "0" || "${right}" != "0" ]]; then
-  echo "parent-dev mirror drift detected: upstream/dev...origin/parent-dev = ${counts}" >&2
+if [[ "${right}" != "0" ]]; then
+  echo "parent-dev has commits missing from upstream/dev: upstream/dev...origin/parent-dev = ${counts}" >&2
+  echo "Refusing to continue because this is unsafe mirror drift." >&2
   exit 1
+fi
+
+if [[ "${left}" != "0" ]]; then
+  echo "parent-dev is stale by ${left} commit(s): upstream/dev...origin/parent-dev = ${counts}"
+  echo "Continuing: sync-upstream will force-refresh parent-dev from upstream/dev."
+  exit 0
 fi
 
 echo "parent-dev mirror verified: upstream/dev...origin/parent-dev = ${counts}"


### PR DESCRIPTION
## Problem
`verify-upstream-mirror.sh` hard-failed when `upstream/dev` advanced ahead of `origin/parent-dev` (for example `1 0`).

That stale state is expected between sync runs and is exactly what `script/sync-upstream.ts` is supposed to repair by force-refreshing `parent-dev`.

## Fix
- update `script/verify-upstream-mirror.sh` semantics:
  - fail only when `origin/parent-dev` has commits missing from `upstream/dev` (`right > 0`, unsafe drift)
  - allow upstream-ahead stale state (`left > 0`) and continue with a warning
- rename workflow step label to `Verify parent-dev mirror health`
- update runbook text in `docs/upstream-sync.md` to match the new health-check behavior

## Validation
- local run now reports stale as warning and exits successfully:
  - `parent-dev is stale by 6 commit(s): upstream/dev...origin/parent-dev = 6 0`
  - `Continuing: sync-upstream will force-refresh parent-dev from upstream/dev.`
