### PR TITLE
fix(sync): add id-token: write permission for Claude Code Action OIDC

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   sync:


### PR DESCRIPTION
The claude-code-action@v1 uses OIDC to generate short-lived GitHub tokens and requires the id-token: write workflow permission.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the pr.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
