### PR TITLE
fix(ci): re-setup bun after upstream merge to handle version bumps

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -103,6 +103,12 @@ jobs:
         if: always() && steps.sync.outputs.has_conflicts == 'true'
         run: cp -f "$RUNNER_TEMP/claude-execution-output.json" "$RUNNER_TEMP/claude-resolve.json" 2>/dev/null || true
 
+      # After merge/resolution, package.json may require a newer Bun version
+      # from upstream. Re-setup to match the merged state.
+      - name: Re-setup Bun (post-merge)
+        if: steps.sync.outputs.sync_branch != ''
+        uses: ./.github/actions/setup-bun
+
       # ── Phase 3: Run tests ────────────────────────────────
       - name: Run tests after merge/resolution
         id: test1


### PR DESCRIPTION
When upstream bumps the bun version in package.json, the pre-push hook rejects the push because the CI runner still has the old version from initial setup. Re-run setup-bun after merge/resolution to pick up any version changes before tests and push.

Closes #30

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the pr.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
